### PR TITLE
improve: `companion.c`, `dl.c` and `utils.c` code

### DIFF
--- a/zygiskd/src/dl.c
+++ b/zygiskd/src/dl.c
@@ -13,14 +13,13 @@
 #include <android/log.h>
 
 #include "companion.h"
-#include "dl.h"
 #include "utils.h"
 
 #define ANDROID_NAMESPACE_TYPE_SHARED 0x2
 #define ANDROID_DLEXT_USE_NAMESPACE 0x200
 
 typedef struct AndroidNamespace {
-  unsigned char _unused[0];
+  uint8_t _unused[0];
 } AndroidNamespace;
 
 typedef struct AndroidDlextinfo {
@@ -33,6 +32,8 @@ typedef struct AndroidDlextinfo {
   AndroidNamespace *library_namespace;
 } AndroidDlextinfo;
 
+extern void *android_dlopen_ext(const char *filename, int flags, const AndroidDlextinfo *extinfo);
+
 typedef AndroidNamespace *(*AndroidCreateNamespaceFn)(
   const char *name,
   const char *ld_library_path,
@@ -42,8 +43,6 @@ typedef AndroidNamespace *(*AndroidCreateNamespaceFn)(
   AndroidNamespace *parent,
   const void *caller_addr
 );
-
-extern void *android_dlopen_ext(const char *filename, int flags, const AndroidDlextinfo *extinfo);
 
 void *android_dlopen(char *path, int flags) {
   char *dir = dirname(path);

--- a/zygiskd/src/utils.h
+++ b/zygiskd/src/utils.h
@@ -91,7 +91,7 @@ read_func_def(uint8_t);
 
 ssize_t write_string(int fd, const char *restrict str);
 
-ssize_t read_string(int fd, char *restrict str, size_t len);
+ssize_t read_string(int fd, char *restrict buf, size_t buf_size);
 
 bool exec_command(char *restrict buf, size_t len, const char *restrict file, char *const argv[]);
 


### PR DESCRIPTION
This commit improves the code for multiple files by making "read_string" function already make the string NULL-terminated, avoiding code duplication. Also for "companion.c" fixes an "if" where it would read "client_fd" and check if "fd" is equal to "-1", instead of "client_fd", also does some overall code improvements there like detaching the thread, avoiding memory leaks in the exit, of the thread itself.

## Changes

Write here about the changes you've made

## Why 

Write here why you think this should be merged

## Checkmarks

- [ ] The modified functions have been tested.
- [ ] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog).

## Additional information

If you have any additional information, write it here
